### PR TITLE
Erweitere Zeitperiode um to_iso8601 Funktion

### DIFF
--- a/apps/jehovakel_ex_times/lib/zeitperiode.ex
+++ b/apps/jehovakel_ex_times/lib/zeitperiode.ex
@@ -49,7 +49,7 @@ defmodule Shared.Zeitperiode do
   def new(%NaiveDateTime{} = von, %NaiveDateTime{} = bis), do: to_interval(von, bis)
 
   def from_interval(interval) when is_binary(interval) do
-    [start: start, ende: ende] = parse_interval(interval)
+    [start: start, ende: ende] = parse(interval)
     new(start, ende)
   end
 

--- a/apps/jehovakel_ex_times/lib/zeitperiode.ex
+++ b/apps/jehovakel_ex_times/lib/zeitperiode.ex
@@ -85,14 +85,17 @@ defmodule Shared.Zeitperiode do
 
   def to_string(periode), do: Timex.Interval.format!(periode, "%Y-%m-%d %H:%M", :strftime)
 
+  @spec to_iso8601(Timex.Interval.t()) :: binary()
   def to_iso8601(%Timex.Interval{from: %NaiveDateTime{} = von, until: %NaiveDateTime{} = bis}) do
     [von, bis] |> Enum.map(&NaiveDateTime.to_iso8601/1) |> Enum.join("/")
   end
 
+  @spec to_iso8601(start: DateTime.t(), ende: DateTime.t()) :: binary()
   def to_iso8601(start: %DateTime{} = start, ende: %DateTime{} = ende) do
     [start, ende] |> Enum.map(&DateTime.to_iso8601/1) |> Enum.join("/")
   end
 
+  @spec to_iso8601(start: DateTime.t(), ende: DateTime.t()) :: binary()
   def to_iso8601(start: %NaiveDateTime{} = start, ende: %NaiveDateTime{} = ende) do
     [start, ende] |> Enum.map(&NaiveDateTime.to_iso8601/1) |> Enum.join("/")
   end

--- a/apps/jehovakel_ex_times/lib/zeitperiode.ex
+++ b/apps/jehovakel_ex_times/lib/zeitperiode.ex
@@ -85,6 +85,18 @@ defmodule Shared.Zeitperiode do
 
   def to_string(periode), do: Timex.Interval.format!(periode, "%Y-%m-%d %H:%M", :strftime)
 
+  def to_iso8601(%Timex.Interval{from: %NaiveDateTime{} = von, until: %NaiveDateTime{} = bis}) do
+    [von, bis] |> Enum.map(&NaiveDateTime.to_iso8601/1) |> Enum.join("/")
+  end
+
+  def to_iso8601(start: %DateTime{} = start, ende: %DateTime{} = ende) do
+    [start, ende] |> Enum.map(&DateTime.to_iso8601/1) |> Enum.join("/")
+  end
+
+  def to_iso8601(start: %NaiveDateTime{} = start, ende: %NaiveDateTime{} = ende) do
+    [start, ende] |> Enum.map(&NaiveDateTime.to_iso8601/1) |> Enum.join("/")
+  end
+
   defp to_interval(von, bis) do
     Timex.Interval.new(
       from: von,

--- a/apps/jehovakel_ex_times/lib/zeitperiode.ex
+++ b/apps/jehovakel_ex_times/lib/zeitperiode.ex
@@ -103,6 +103,7 @@ defmodule Shared.Zeitperiode do
   def parse(interval) when is_binary(interval) do
     [start, ende] =
       interval
+      |> String.replace("--", "/")
       |> String.split("/")
 
     [start: start |> Shared.Zeit.parse(), ende: ende |> Shared.Zeit.parse()]

--- a/apps/jehovakel_ex_times/lib/zeitperiode_test.exs
+++ b/apps/jehovakel_ex_times/lib/zeitperiode_test.exs
@@ -295,6 +295,32 @@ defmodule Shared.ZeitperiodeTest do
     end
   end
 
+  describe "to_iso8601/1" do
+    test "formatiere Periode als naives ISO8601 Intervall" do
+      assert periode = Periode.new(~N[2020-03-16 18:23:00], ~N[2020-04-02 08:38:11])
+      assert "2020-03-16T18:23:00/2020-04-02T08:38:11" == Periode.to_iso8601(periode)
+    end
+
+    test "formatiere Intervall als ISO8601 Intervall" do
+      intervall_string = "2020-03-16T18:23:00+01:00/2020-04-02T08:38:11+02:00"
+      assert intervall = Periode.parse(intervall_string)
+      assert intervall_string == Periode.to_iso8601(intervall)
+    end
+
+    test "formatiere naives Intervall als ISO8601 Intervall" do
+      intervall_string = "2020-03-16T18:23:00/2020-04-02T08:38:11"
+      assert intervall = Periode.parse(intervall_string)
+      assert intervall_string == Periode.to_iso8601(intervall)
+    end
+
+    test "Perioden und Intervalle sind unterschiedlich" do
+      intervall_string = "2020-03-16T18:23:00+01:00/2020-04-02T08:38:11+02:00"
+      assert intervall = Periode.parse(intervall_string)
+      assert periode = Periode.from_interval(intervall_string)
+      refute Periode.to_iso8601(intervall) == Periode.to_iso8601(periode)
+    end
+  end
+
   describe "teil_von?/2" do
     test "erkennt, ob ein Periode komplett in einem anderen Periode liegt" do
       periode = Periode.new(~D[2018-03-20], ~T[23:00:00], ~T[00:00:00])

--- a/apps/jehovakel_ex_times/lib/zeitperiode_test.exs
+++ b/apps/jehovakel_ex_times/lib/zeitperiode_test.exs
@@ -290,6 +290,8 @@ defmodule Shared.ZeitperiodeTest do
     test "parse ISO8601 Zeitintervall" do
       assert Periode.parse("2019-04-16T23:30:00+02:00/2019-04-16T23:45:00+02:00")
              |> entspricht_intervall?("2019-04-16T23:30:00+02:00/2019-04-16T23:45:00+02:00")
+      assert Periode.parse("2019-04-16T23:30:00+02:00--2019-04-16T23:45:00+02:00")
+             |> entspricht_intervall?("2019-04-16T23:30:00+02:00/2019-04-16T23:45:00+02:00")
     end
   end
 


### PR DESCRIPTION
Wir können ISO8601 Intervalle zwar parsen, aber ein Intervall oder eine Zeitperiode kann nicht wieder als ISO8601 formatiert ausgegeben werden. Daher würde ich vorschlagen diese Funktion zum `Zeitperiode` Modul hinzuzufügen.

Neben einem `/` kann ein ISO8601 Intervall auch `--` als Trennzeichen verwenden. Unterstützung dafür habe ich ebenfalls hinzugefügt.

Darüberhinaus habe ich die Verwendung der veralteten `parse_interval` Funktion innerhalb des `Zeitperiode` Moduls ersetzt.