### PR TITLE
Fuege specs hinzu

### DIFF
--- a/apps/jehovakel_ex_times/lib/zeit.ex
+++ b/apps/jehovakel_ex_times/lib/zeit.ex
@@ -1,6 +1,7 @@
 defmodule Shared.Zeit do
   alias Shared.Zeitperiode
 
+  @spec mit_deutscher_zeitzone(date :: Date.t, time :: Time.t) :: DateTime.t
   @doc """
   Wandelt ein Datum und eine Zeit in ein DateTime Struct mit deutscher Zeitzone
   um. Es wird also angenommen, dass die übergebene Zeit in Deutschland statt
@@ -16,17 +17,20 @@ defmodule Shared.Zeit do
     |> mit_deutscher_zeitzone()
   end
 
+  @spec mit_deutscher_zeitzone(NaiveDateTime.t) :: DateTime.t
   def mit_deutscher_zeitzone(%NaiveDateTime{} = datetime) do
     datetime
     |> Timex.to_datetime("Europe/Berlin")
   end
 
+  @spec mit_deutscher_zeitzone(DateTime.t) :: DateTime.t
   def mit_deutscher_zeitzone(%DateTime{} = datetime) do
     datetime
     |> DateTime.to_naive()
     |> mit_deutscher_zeitzone()
   end
 
+  @spec mit_deutscher_zeitzone(datum :: Date.t, start :: Time.t, ende :: Time.t) :: Timex.Interval.t()
   def mit_deutscher_zeitzone(%Date{} = datum, %Time{} = start, %Time{} = ende) do
     zeitperiode = Zeitperiode.new(datum, start, ende)
 
@@ -37,16 +41,19 @@ defmodule Shared.Zeit do
     )
   end
 
+  @spec parse(binary) :: DateTime.t | NaiveDateTime.t
   def parse(to_parse) when is_binary(to_parse) do
     {:ok, date_time} = Timex.parse(to_parse, "{ISO:Extended}")
     date_time
   end
 
+  @spec jetzt :: DateTime.t
   def jetzt do
     Timex.local() |> DateTime.truncate(:second)
   end
 
   defmodule Sigil do
+    @spec sigil_G(binary, _ :: charlist()) :: DateTime.t
     @doc """
     Wandelt ISO8601 Date Strings und Time Strings in DateTime mit deutscher Zeitzone
 

--- a/apps/jehovakel_ex_times/lib/zeit.ex
+++ b/apps/jehovakel_ex_times/lib/zeit.ex
@@ -1,7 +1,7 @@
 defmodule Shared.Zeit do
   alias Shared.Zeitperiode
 
-  @spec mit_deutscher_zeitzone(date :: Date.t, time :: Time.t) :: DateTime.t
+  @spec mit_deutscher_zeitzone(datum :: Date.t, zeit :: Time.t) :: DateTime.t
   @doc """
   Wandelt ein Datum und eine Zeit in ein DateTime Struct mit deutscher Zeitzone
   um. Es wird also angenommen, dass die übergebene Zeit in Deutschland statt
@@ -53,7 +53,7 @@ defmodule Shared.Zeit do
   end
 
   defmodule Sigil do
-    @spec sigil_G(binary, _ :: charlist()) :: DateTime.t
+    @spec sigil_G(term :: binary(), _modifiers :: charlist()) :: DateTime.t
     @doc """
     Wandelt ISO8601 Date Strings und Time Strings in DateTime mit deutscher Zeitzone
 

--- a/apps/jehovakel_ex_times/lib/zeit.ex
+++ b/apps/jehovakel_ex_times/lib/zeit.ex
@@ -1,7 +1,7 @@
 defmodule Shared.Zeit do
   alias Shared.Zeitperiode
 
-  @spec mit_deutscher_zeitzone(datum :: Date.t, zeit :: Time.t) :: DateTime.t
+  @spec mit_deutscher_zeitzone(datum :: Date.t(), zeit :: Time.t()) :: DateTime.t()
   @doc """
   Wandelt ein Datum und eine Zeit in ein DateTime Struct mit deutscher Zeitzone
   um. Es wird also angenommen, dass die übergebene Zeit in Deutschland statt
@@ -17,20 +17,21 @@ defmodule Shared.Zeit do
     |> mit_deutscher_zeitzone()
   end
 
-  @spec mit_deutscher_zeitzone(NaiveDateTime.t) :: DateTime.t
+  @spec mit_deutscher_zeitzone(NaiveDateTime.t()) :: DateTime.t()
   def mit_deutscher_zeitzone(%NaiveDateTime{} = datetime) do
     datetime
     |> Timex.to_datetime("Europe/Berlin")
   end
 
-  @spec mit_deutscher_zeitzone(DateTime.t) :: DateTime.t
+  @spec mit_deutscher_zeitzone(DateTime.t()) :: DateTime.t()
   def mit_deutscher_zeitzone(%DateTime{} = datetime) do
     datetime
     |> DateTime.to_naive()
     |> mit_deutscher_zeitzone()
   end
 
-  @spec mit_deutscher_zeitzone(datum :: Date.t, start :: Time.t, ende :: Time.t) :: Timex.Interval.t()
+  @spec mit_deutscher_zeitzone(datum :: Date.t(), start :: Time.t(), ende :: Time.t()) ::
+          Timex.Interval.t()
   def mit_deutscher_zeitzone(%Date{} = datum, %Time{} = start, %Time{} = ende) do
     zeitperiode = Zeitperiode.new(datum, start, ende)
 
@@ -41,19 +42,19 @@ defmodule Shared.Zeit do
     )
   end
 
-  @spec parse(binary) :: DateTime.t | NaiveDateTime.t
+  @spec parse(binary) :: DateTime.t() | NaiveDateTime.t()
   def parse(to_parse) when is_binary(to_parse) do
     {:ok, date_time} = Timex.parse(to_parse, "{ISO:Extended}")
     date_time
   end
 
-  @spec jetzt :: DateTime.t
+  @spec jetzt :: DateTime.t()
   def jetzt do
     Timex.local() |> DateTime.truncate(:second)
   end
 
   defmodule Sigil do
-    @spec sigil_G(term :: binary(), _modifiers :: charlist()) :: DateTime.t
+    @spec sigil_G(term :: binary(), _modifiers :: charlist()) :: DateTime.t()
     @doc """
     Wandelt ISO8601 Date Strings und Time Strings in DateTime mit deutscher Zeitzone
 

--- a/apps/jehovakel_ex_times/lib/zeit.ex
+++ b/apps/jehovakel_ex_times/lib/zeit.ex
@@ -18,13 +18,13 @@ defmodule Shared.Zeit do
 
   def mit_deutscher_zeitzone(%NaiveDateTime{} = datetime) do
     datetime
-    |> DateTime.from_naive!("Etc/UTC")
-    |> mit_deutscher_zeitzone()
+    |> Timex.to_datetime("Europe/Berlin")
   end
 
   def mit_deutscher_zeitzone(%DateTime{} = datetime) do
     datetime
-    |> Timex.set(timezone: "Europe/Berlin")
+    |> DateTime.to_naive()
+    |> mit_deutscher_zeitzone()
   end
 
   def mit_deutscher_zeitzone(%Date{} = datum, %Time{} = start, %Time{} = ende) do

--- a/apps/jehovakel_ex_times/lib/zeitperiode.ex
+++ b/apps/jehovakel_ex_times/lib/zeitperiode.ex
@@ -3,10 +3,13 @@ defmodule Shared.Zeitperiode do
   Repräsentiert eine Arbeitszeit-Periode oder Schicht
   """
   @type t :: Timex.Interval.t()
-  @type interval :: [start: DateTime.t | NaiveDateTime.t, ende: DateTime.t | NaiveDateTime.t]
+  @type interval :: [
+          start: DateTime.t() | NaiveDateTime.t(),
+          ende: DateTime.t() | NaiveDateTime.t()
+        ]
   @default_base_timezone_name "Europe/Berlin"
 
-  @spec new(kalendertag :: Date.t, von :: Time.t, bis :: Time.t) :: t
+  @spec new(kalendertag :: Date.t(), von :: Time.t(), bis :: Time.t()) :: t
   def new(%Date{} = kalendertag, %Time{} = von, %Time{} = bis) when von < bis do
     von_als_datetime = to_datetime(kalendertag, von)
     bis_als_datetime = to_datetime(kalendertag, bis)
@@ -24,7 +27,7 @@ defmodule Shared.Zeitperiode do
   end
 
   # Basiszeitzone ist die Zeitzone, in der die Zeit erfasst wurde, aktuell immer Dtl.
-  @spec new(von :: DateTime.t, bis :: DateTime.t, base_timezone_name :: String.t) :: t
+  @spec new(von :: DateTime.t(), bis :: DateTime.t(), base_timezone_name :: String.t()) :: t
   def new(%DateTime{} = von, %DateTime{} = bis, base_timezone_name) do
     von = Shared.Zeitperiode.Timezone.convert(von, base_timezone_name)
 
@@ -44,16 +47,16 @@ defmodule Shared.Zeitperiode do
     to_interval(von_naive, bis_naive)
   end
 
-  @spec new(von :: DateTime.t, bis :: DateTime.t) :: t
+  @spec new(von :: DateTime.t(), bis :: DateTime.t()) :: t
   def new(%DateTime{} = von, %DateTime{} = bis) do
     # default value using `\\` produces the warning `definitions with multiple clauses and default values require a header.`
     new(von, bis, @default_base_timezone_name)
   end
 
-  @spec new(von :: NaiveDateTime.t, bis :: NaiveDateTime.t) :: t
+  @spec new(von :: NaiveDateTime.t(), bis :: NaiveDateTime.t()) :: t
   def new(%NaiveDateTime{} = von, %NaiveDateTime{} = bis), do: to_interval(von, bis)
 
-  @spec from_interval(interval :: String.t) :: t
+  @spec from_interval(interval :: String.t()) :: t
   def from_interval(interval) when is_binary(interval) do
     [start: start, ende: ende] = parse_interval(interval)
     new(start, ende)
@@ -65,10 +68,10 @@ defmodule Shared.Zeitperiode do
   @spec bis(t) :: Timex.Types.valid_datetime()
   def bis(periode), do: periode.until
 
-  @spec von_datum(t) :: Date.t
+  @spec von_datum(t) :: Date.t()
   def von_datum(periode), do: periode |> von() |> NaiveDateTime.to_date()
 
-  @spec bis_datum(t) :: Date.t
+  @spec bis_datum(t) :: Date.t()
   def bis_datum(%{until: %{hour: 0, minute: 0, second: 0}} = periode) do
     periode |> bis() |> NaiveDateTime.to_date() |> Timex.shift(days: -1)
   end
@@ -99,7 +102,7 @@ defmodule Shared.Zeitperiode do
     NaiveDateTime.compare(periode1.from, periode2.from) == :lt
   end
 
-  @spec to_string(t) :: String.t
+  @spec to_string(t) :: String.t()
   def to_string(periode), do: Timex.Interval.format!(periode, "%Y-%m-%d %H:%M", :strftime)
 
   defp to_interval(von, bis) do
@@ -144,7 +147,8 @@ defmodule Shared.Zeitperiode do
   defp duration(periode, :minutes),
     do: periode |> duration(:duration) |> Timex.Duration.to_minutes() |> Float.round()
 
-  @spec dauer_der_ueberschneidung(periode1 :: Timex.Interval.t(), periode2 :: Timex.Interval.t()) :: Timex.Duration.t()
+  @spec dauer_der_ueberschneidung(periode1 :: Timex.Interval.t(), periode2 :: Timex.Interval.t()) ::
+          Timex.Duration.t()
   def dauer_der_ueberschneidung(periode1, periode2) do
     dauer1 = dauer(periode1)
 
@@ -159,7 +163,10 @@ defmodule Shared.Zeitperiode do
   end
 
   defmodule Timezone do
-    @spec convert(DateTime.t, binary() | Timex.AmbiguousTimezoneInfo.t() | Timex.TimezoneInfo.t()) :: DateTime.t | Timex.AmbiguousDateTime.t()
+    @spec convert(
+            DateTime.t(),
+            binary() | Timex.AmbiguousTimezoneInfo.t() | Timex.TimezoneInfo.t()
+          ) :: DateTime.t() | Timex.AmbiguousDateTime.t()
     def convert(datetime, timezone) do
       case Timex.Timezone.convert(datetime, timezone) do
         {:error, _} ->

--- a/apps/jehovakel_ex_times/lib/zeitperiode.ex
+++ b/apps/jehovakel_ex_times/lib/zeitperiode.ex
@@ -3,8 +3,10 @@ defmodule Shared.Zeitperiode do
   Repräsentiert eine Arbeitszeit-Periode oder Schicht
   """
   @type t :: Timex.Interval.t()
+  @type interval :: [start: DateTime.t | NaiveDateTime.t, ende: DateTime.t | NaiveDateTime.t]
   @default_base_timezone_name "Europe/Berlin"
 
+  @spec new(kalendertag :: Date.t, von :: Time.t, bis :: Time.t) :: t
   def new(%Date{} = kalendertag, %Time{} = von, %Time{} = bis) when von < bis do
     von_als_datetime = to_datetime(kalendertag, von)
     bis_als_datetime = to_datetime(kalendertag, bis)
@@ -22,6 +24,7 @@ defmodule Shared.Zeitperiode do
   end
 
   # Basiszeitzone ist die Zeitzone, in der die Zeit erfasst wurde, aktuell immer Dtl.
+  @spec new(von :: DateTime.t, bis :: DateTime.t, base_timezone_name :: String.t) :: t
   def new(%DateTime{} = von, %DateTime{} = bis, base_timezone_name) do
     von = Shared.Zeitperiode.Timezone.convert(von, base_timezone_name)
 
@@ -41,24 +44,31 @@ defmodule Shared.Zeitperiode do
     to_interval(von_naive, bis_naive)
   end
 
+  @spec new(von :: DateTime.t, bis :: DateTime.t) :: t
   def new(%DateTime{} = von, %DateTime{} = bis) do
     # default value using `\\` produces the warning `definitions with multiple clauses and default values require a header.`
     new(von, bis, @default_base_timezone_name)
   end
 
+  @spec new(von :: NaiveDateTime.t, bis :: NaiveDateTime.t) :: t
   def new(%NaiveDateTime{} = von, %NaiveDateTime{} = bis), do: to_interval(von, bis)
 
+  @spec from_interval(interval :: String.t) :: t
   def from_interval(interval) when is_binary(interval) do
     [start: start, ende: ende] = parse_interval(interval)
     new(start, ende)
   end
 
+  @spec von(t) :: Timex.Types.valid_datetime()
   def von(periode), do: periode.from
 
+  @spec bis(t) :: Timex.Types.valid_datetime()
   def bis(periode), do: periode.until
 
+  @spec von_datum(t) :: Date.t
   def von_datum(periode), do: periode |> von() |> NaiveDateTime.to_date()
 
+  @spec bis_datum(t) :: Date.t
   def bis_datum(%{until: %{hour: 0, minute: 0, second: 0}} = periode) do
     periode |> bis() |> NaiveDateTime.to_date() |> Timex.shift(days: -1)
   end
@@ -67,22 +77,29 @@ defmodule Shared.Zeitperiode do
     periode |> bis() |> NaiveDateTime.to_date()
   end
 
+  @spec dauer(t) :: number | {:error, any} | Timex.Duration.t()
   def dauer(periode), do: duration(periode, :duration)
+  @spec dauer_in_stunden(t) :: number | {:error, any} | Timex.Duration.t()
   def dauer_in_stunden(periode), do: duration(periode, :hours)
+  @spec dauer_in_minuten(t) :: number | {:error, any} | Timex.Duration.t()
   def dauer_in_minuten(periode), do: duration(periode, :minutes)
 
+  @spec ueberschneidung?(periode :: t, andere_periode :: t) :: boolean
   def ueberschneidung?(periode, andere_periode) do
     periode.from in andere_periode || andere_periode.from in periode
   end
 
+  @spec teil_von?(zu_testende_periode :: t, periode :: t) :: boolean
   def teil_von?(zu_testende_periode, periode) do
     zu_testende_periode.from in periode && zu_testende_periode.until in periode
   end
 
+  @spec beginnt_vor?(periode1 :: t, periode2 :: t) :: boolean
   def beginnt_vor?(periode1, periode2) do
     NaiveDateTime.compare(periode1.from, periode2.from) == :lt
   end
 
+  @spec to_string(t) :: String.t
   def to_string(periode), do: Timex.Interval.format!(periode, "%Y-%m-%d %H:%M", :strftime)
 
   defp to_interval(von, bis) do
@@ -100,6 +117,7 @@ defmodule Shared.Zeitperiode do
     parse(interval)
   end
 
+  @spec parse(binary) :: interval()
   def parse(interval) when is_binary(interval) do
     [start, ende] =
       interval
@@ -126,6 +144,7 @@ defmodule Shared.Zeitperiode do
   defp duration(periode, :minutes),
     do: periode |> duration(:duration) |> Timex.Duration.to_minutes() |> Float.round()
 
+  @spec dauer_der_ueberschneidung(periode1 :: Timex.Interval.t(), periode2 :: Timex.Interval.t()) :: Timex.Duration.t()
   def dauer_der_ueberschneidung(periode1, periode2) do
     dauer1 = dauer(periode1)
 
@@ -140,6 +159,7 @@ defmodule Shared.Zeitperiode do
   end
 
   defmodule Timezone do
+    @spec convert(DateTime.t, binary() | Timex.AmbiguousTimezoneInfo.t() | Timex.TimezoneInfo.t()) :: DateTime.t | Timex.AmbiguousDateTime.t()
     def convert(datetime, timezone) do
       case Timex.Timezone.convert(datetime, timezone) do
         {:error, _} ->

--- a/apps/jehovakel_ex_times/lib/zeitperiode.ex
+++ b/apps/jehovakel_ex_times/lib/zeitperiode.ex
@@ -117,7 +117,7 @@ defmodule Shared.Zeitperiode do
     parse(interval)
   end
 
-  @spec parse(binary) :: interval()
+  @spec parse(binary()) :: interval()
   def parse(interval) when is_binary(interval) do
     [start, ende] =
       interval


### PR DESCRIPTION
Die öffentlichen Funktionen der Module `Zeit` und `Zeitperiode` haben keine `@spec` Definitionen.

Außerdem wurde in `Zeit.mit_deutscher_zeitzone/1` ein undokumentiertes Feature von `Timex` verwendet: das setzen der Zeitzone in `Timex.set`.